### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,10 @@ on:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   release:
     name: Release


### PR DESCRIPTION
Potential fix for [https://github.com/sectsect/solid-hiding-header/security/code-scanning/1](https://github.com/sectsect/solid-hiding-header/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the workflow's operations, the following permissions are appropriate:
- `contents: read` for accessing repository contents.
- `pull-requests: write` for creating release pull requests via the `changesets/action` step.

The `permissions` block should be added at the root level of the workflow to apply to all jobs unless overridden by job-specific permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
